### PR TITLE
Fixed incorrect coloring on URL previews

### DIFF
--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -93,6 +93,14 @@ $colors: (
         light: rgba(0, 0, 0, 0.1),
         dark: rgba(255, 255, 255, 0.1)
     ),
+    tapback-background: (
+        light: rgba(255, 255, 255, 1),
+        dark: rgba(32, 33, 36, 1)
+    ),
+    to-text: (
+        light: rgba(0, 0, 0, 0.6),
+        dark: rgba(157, 157, 157, 1)
+    ),
     lp-bottom-caption: rgb(142, 142, 145)
 );
 

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -94,8 +94,8 @@ $colors: (
         dark: rgba(255, 255, 255, 0.1)
     ),
     tapback-background: (
-        light: rgba(255, 255, 255, 1),
-        dark: rgba(32, 33, 36, 1)
+        light: rgba(45, 45, 46, 255),
+        dark: rgba(45, 45, 46, 255)
     ),
     to-text: (
         light: rgba(0, 0, 0, 0.6),

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -94,7 +94,7 @@ $colors: (
         dark: rgba(255, 255, 255, 0.1)
     ),
     tapback-background: (
-        light: rgba(45, 45, 46, 255),
+        light: rgba(255, 255, 255, 1),
         dark: rgba(45, 45, 46, 255)
     ),
     to-text: (

--- a/src/styles/ack-picker/AcknowledgmentPicker.scss
+++ b/src/styles/ack-picker/AcknowledgmentPicker.scss
@@ -13,7 +13,7 @@
     width: 200px;
     column-gap: 5px;
 
-    background: white;
+    background: var(--tapback-background);
 
     border-radius: 25px;
 
@@ -39,7 +39,7 @@
         }
 
         &::before {
-            background-color: white;
+            background-color: var(--tapback-background);
         }
 
         &[attr-selected=true] {

--- a/src/styles/ack-picker/AcknowledgmentPicker.scss
+++ b/src/styles/ack-picker/AcknowledgmentPicker.scss
@@ -15,8 +15,6 @@
 
     background: var(--tapback-background);
 
-    border-radius: 25px;
-
     padding: 2.5px 7.5px;
 
     .acknowledgment-button {

--- a/src/styles/toolbar/_transcript-toolbar.scss
+++ b/src/styles/toolbar/_transcript-toolbar.scss
@@ -13,7 +13,7 @@
 
         &::before {
             content: 'To: ';
-            color: rgba(0, 0, 0, 0.6);
+            color: var(--to-text);
         }
     }
 

--- a/src/styles/transcript/items/LPRichLink.scss
+++ b/src/styles/transcript/items/LPRichLink.scss
@@ -8,7 +8,7 @@
         --lp-background-override: var(--dark-lp-background-override);
     }
 
-    background-color: var(--lp-background-override, rgb(229, 230, 233));
+    background-color: var(--lp-background-override, var(--not-from-me));
 
     max-width: 300px;
 


### PR DESCRIPTION
Below is a before/after comparison.
![Before URL](https://user-images.githubusercontent.com/53708281/123863235-56388b00-d8f7-11eb-8019-260f9ca1d667.png)
![After URL](https://user-images.githubusercontent.com/53708281/123863240-58024e80-d8f7-11eb-8052-cb2e4adb47fa.png)
https://github.com/open-imcore/imessage-rest/issues/22