### PR TITLE
Changed dark mode to more closely resemble iOS

### DIFF
--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -93,6 +93,14 @@ $colors: (
         light: rgba(0, 0, 0, 0.1),
         dark: rgba(255, 255, 255, 0.1)
     ),
+    tapback-background: (
+        light: rgba(255, 255, 255, 1),
+        dark: rgba(32, 33, 36, 1)
+    ),
+    to-text: (
+        light: rgba(0, 0, 0, 0.6),
+        dark: rgba(157, 157, 157, 1)
+    ),
     lp-bottom-caption: rgb(142, 142, 145)
 );
 

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -94,8 +94,8 @@ $colors: (
         dark: rgba(255, 255, 255, 0.1)
     ),
     tapback-background: (
-        light: rgba(255, 255, 255, 1),
-        dark: rgba(32, 33, 36, 1)
+        light: rgba(45, 45, 46, 255),
+        dark: rgba(45, 45, 46, 255)
     ),
     to-text: (
         light: rgba(0, 0, 0, 0.6),

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -94,7 +94,7 @@ $colors: (
         dark: rgba(255, 255, 255, 0.1)
     ),
     tapback-background: (
-        light: rgba(45, 45, 46, 255),
+        light: rgba(255, 255, 255, 1),
         dark: rgba(45, 45, 46, 255)
     ),
     to-text: (

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -14,7 +14,7 @@ $colors: (
     from-me-text: white,
     not-from-me: (
         light: rgb(229,229,234),
-        dark: #3B3B3D
+        dark: #272729
     ),
     not-from-me-text: (
         light: black,
@@ -29,11 +29,11 @@ $colors: (
     active-chat-text: white,
     master-detail-background: (
         light: #F0F0F0,
-        dark: #242424
+        dark: #010001
     ),
     master-detail-border-color: (
         light: #E2E2E2,
-        dark: #424242
+        dark: #2a2a2c
     ),
     chat-sidebar-title: (
         light: #555655,
@@ -41,11 +41,11 @@ $colors: (
     ),
     ack-bubble-background: (
         light: rgb(229, 229, 234),
-        dark: rgb(92, 86, 84)
+        dark: rgb(39, 39, 41)
     ),
     ack-glyph-color: (
         light: rgb(124, 124, 124),
-        dark: rgb(206, 206, 210)
+        dark: rgb(129, 129, 128)
     ),
     chat-sidebar-description: #808080,
     blue-text: #2888F6,
@@ -61,7 +61,7 @@ $colors: (
         light: linear-gradient($transcript-business-chat-gradient-stop, $transcript-business-chat-gradient-start),
         dark: linear-gradient($transcript-business-chat-gradient-dark-stop, $transcript-business-chat-gradient-dark-start)
     ),
-    heart-active: #E86895,
+    heart-active: #FA5C99,
     ack-active: white,
     attachment-background: (
         light: #E9E9EB,
@@ -75,7 +75,7 @@ $colors: (
     ),
     composition-placeholder: (
         light: rgba(0, 0, 0, 0.3),
-        dark: rgba(255, 255, 255, 0.3)
+        dark: rgba(70, 71, 75, 255)
     ),
     text: (
         light: black,
@@ -87,7 +87,7 @@ $colors: (
     ),
     background: (
         light: white,
-        dark: #1E1E1E
+        dark: #010001
     ),
     background-secondary: (
         light: rgba(0, 0, 0, 0.1),

--- a/src/styles/ack-picker/AcknowledgmentPicker.scss
+++ b/src/styles/ack-picker/AcknowledgmentPicker.scss
@@ -13,7 +13,7 @@
     width: 200px;
     column-gap: 5px;
 
-    background: white;
+    background: var(--tapback-background);
 
     border-radius: 25px;
 
@@ -39,7 +39,7 @@
         }
 
         &::before {
-            background-color: white;
+            background-color: var(--tapback-background);
         }
 
         &[attr-selected=true] {

--- a/src/styles/ack-picker/AcknowledgmentPicker.scss
+++ b/src/styles/ack-picker/AcknowledgmentPicker.scss
@@ -15,8 +15,6 @@
 
     background: var(--tapback-background);
 
-    border-radius: 25px;
-
     padding: 2.5px 7.5px;
 
     .acknowledgment-button {

--- a/src/styles/toolbar/_transcript-toolbar.scss
+++ b/src/styles/toolbar/_transcript-toolbar.scss
@@ -13,7 +13,7 @@
 
         &::before {
             content: 'To: ';
-            color: rgba(0, 0, 0, 0.6);
+            color: var(--to-text);
         }
     }
 

--- a/src/styles/transcript/items/LPRichLink.scss
+++ b/src/styles/transcript/items/LPRichLink.scss
@@ -8,7 +8,7 @@
         --lp-background-override: var(--dark-lp-background-override);
     }
 
-    background-color: var(--lp-background-override, rgb(229, 230, 233));
+    background-color: var(--lp-background-override, var(--not-from-me));
 
     max-width: 300px;
 


### PR DESCRIPTION
Firstly, below are two screenshots. The first is of the original MyMessage dark mode, and the second is of the changes I made to make it more like iOS.
![Original Dark Mode](https://user-images.githubusercontent.com/53708281/123768745-9ca9cd80-d896-11eb-8228-8458c1297d2c.png)
![iOS Dark Mode](https://user-images.githubusercontent.com/53708281/123768756-9e739100-d896-11eb-9a4b-3a2ac611f2a5.png)
and these are the images I used on https://imagecolorpicker.com/en from my iPad to get the color values (with the exception of the red heart tapback, I got that from [here](https://github.com/sgtaziz/WebMessage/issues/121#issuecomment-796479268))
![PNG image 1](https://user-images.githubusercontent.com/53708281/123768928-c4009a80-d896-11eb-8b1c-7f4b703b8381.png)
![PNG image](https://user-images.githubusercontent.com/53708281/123768924-c4009a80-d896-11eb-84b2-de110df7ed45.png)
![PNG image 2 - Copy](https://user-images.githubusercontent.com/53708281/123768926-c4009a80-d896-11eb-87cc-bb9ec1291d39.png)
![PNG image 1 - Copy](https://user-images.githubusercontent.com/53708281/123768927-c4009a80-d896-11eb-8a71-0ffd5000d158.png)
![PNG image 3](https://user-images.githubusercontent.com/53708281/123768923-c4009a80-d896-11eb-8ca9-123fc7d58fdd.png)
I wasn't able to get a few things (such as the background of the search bar), but I did my best. Let me know what you think of this (perhaps it could be a toggle or third option?)