### PR TITLE
Changed item container `max-width` from `70%` to `37%` to render attachments at a smaller size

### DIFF
--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -93,6 +93,14 @@ $colors: (
         light: rgba(0, 0, 0, 0.1),
         dark: rgba(255, 255, 255, 0.1)
     ),
+    tapback-background: (
+        light: rgba(255, 255, 255, 1),
+        dark: rgba(32, 33, 36, 1)
+    ),
+    to-text: (
+        light: rgba(0, 0, 0, 0.6),
+        dark: rgba(157, 157, 157, 1)
+    ),
     lp-bottom-caption: rgb(142, 142, 145)
 );
 

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -94,8 +94,8 @@ $colors: (
         dark: rgba(255, 255, 255, 0.1)
     ),
     tapback-background: (
-        light: rgba(255, 255, 255, 1),
-        dark: rgba(32, 33, 36, 1)
+        light: rgba(45, 45, 46, 255),
+        dark: rgba(45, 45, 46, 255)
     ),
     to-text: (
         light: rgba(0, 0, 0, 0.6),

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -94,7 +94,7 @@ $colors: (
         dark: rgba(255, 255, 255, 0.1)
     ),
     tapback-background: (
-        light: rgba(45, 45, 46, 255),
+        light: rgba(255, 255, 255, 1),
         dark: rgba(45, 45, 46, 255)
     ),
     to-text: (

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -14,7 +14,7 @@ $colors: (
     from-me-text: white,
     not-from-me: (
         light: rgb(229,229,234),
-        dark: #3B3B3D
+        dark: #272729
     ),
     not-from-me-text: (
         light: black,
@@ -29,11 +29,11 @@ $colors: (
     active-chat-text: white,
     master-detail-background: (
         light: #F0F0F0,
-        dark: #242424
+        dark: #010001
     ),
     master-detail-border-color: (
         light: #E2E2E2,
-        dark: #424242
+        dark: #2a2a2c
     ),
     chat-sidebar-title: (
         light: #555655,
@@ -41,11 +41,11 @@ $colors: (
     ),
     ack-bubble-background: (
         light: rgb(229, 229, 234),
-        dark: rgb(92, 86, 84)
+        dark: rgb(39, 39, 41)
     ),
     ack-glyph-color: (
         light: rgb(124, 124, 124),
-        dark: rgb(206, 206, 210)
+        dark: rgb(129, 129, 128)
     ),
     chat-sidebar-description: #808080,
     blue-text: #2888F6,
@@ -61,7 +61,7 @@ $colors: (
         light: linear-gradient($transcript-business-chat-gradient-stop, $transcript-business-chat-gradient-start),
         dark: linear-gradient($transcript-business-chat-gradient-dark-stop, $transcript-business-chat-gradient-dark-start)
     ),
-    heart-active: #E86895,
+    heart-active: #FA5C99,
     ack-active: white,
     attachment-background: (
         light: #E9E9EB,
@@ -75,7 +75,7 @@ $colors: (
     ),
     composition-placeholder: (
         light: rgba(0, 0, 0, 0.3),
-        dark: rgba(255, 255, 255, 0.3)
+        dark: rgba(70, 71, 75, 255)
     ),
     text: (
         light: black,
@@ -87,7 +87,7 @@ $colors: (
     ),
     background: (
         light: white,
-        dark: #1E1E1E
+        dark: #010001
     ),
     background-secondary: (
         light: rgba(0, 0, 0, 0.1),

--- a/src/styles/_context-menu.scss
+++ b/src/styles/_context-menu.scss
@@ -12,7 +12,7 @@
 
         .react-contexify__item__content {
             padding: 4px 6px;
-            color: white !important;
+            color: var(--not-from-me-text) !important;
         }
     }
 }

--- a/src/styles/ack-picker/AcknowledgmentPicker.scss
+++ b/src/styles/ack-picker/AcknowledgmentPicker.scss
@@ -13,7 +13,7 @@
     width: 200px;
     column-gap: 5px;
 
-    background: white;
+    background: var(--tapback-background);
 
     border-radius: 25px;
 
@@ -39,7 +39,7 @@
         }
 
         &::before {
-            background-color: white;
+            background-color: var(--tapback-background);
         }
 
         &[attr-selected=true] {

--- a/src/styles/ack-picker/AcknowledgmentPicker.scss
+++ b/src/styles/ack-picker/AcknowledgmentPicker.scss
@@ -15,8 +15,6 @@
 
     background: var(--tapback-background);
 
-    border-radius: 25px;
-
     padding: 2.5px 7.5px;
 
     .acknowledgment-button {

--- a/src/styles/ack-picker/AcknowledgmentPicker.scss
+++ b/src/styles/ack-picker/AcknowledgmentPicker.scss
@@ -14,6 +14,7 @@
     column-gap: 5px;
 
     background: var(--tapback-background);
+    border-radius: 25px;
 
     padding: 2.5px 7.5px;
 

--- a/src/styles/toolbar/_transcript-toolbar.scss
+++ b/src/styles/toolbar/_transcript-toolbar.scss
@@ -13,7 +13,7 @@
 
         &::before {
             content: 'To: ';
-            color: rgba(0, 0, 0, 0.6);
+            color: var(--to-text);
         }
     }
 

--- a/src/styles/transcript/AcknowledgmentPickerPresenter.scss
+++ b/src/styles/transcript/AcknowledgmentPickerPresenter.scss
@@ -64,7 +64,7 @@ $acknowledgment-button-initial: scale(1, 1) translate(75px, -100px);
     top: 0;
     left: 0;
 
-    background: white;
+    background: var(--tapback-background);
     border-radius: 25px;
 
     width: 100px;

--- a/src/styles/transcript/items/IMChatItem.scss
+++ b/src/styles/transcript/items/IMChatItem.scss
@@ -190,7 +190,7 @@
         margin-left: 1.5em;
         font-size: 10px;
         margin-bottom: 3px;
-        color: #7e7e7e;
+        color: #7E7E7E;
     }
 
     .buddy-name + [data-has-acknowledgments=true] {
@@ -343,10 +343,11 @@
             mask-border-source: none !important;
             mask-border-slice: none !important;
             mask-border-width: none !important;
-            background: none !important;
+            --bubble-background: var(--background) !important;
             
             &[data-item-type=text] {
                 --font-size: 48px !important;
+                --text-color: var(--background).invert !important;
 
                 .item-inner {
                     padding-left: 8px !important;

--- a/src/styles/transcript/items/IMChatItem.scss
+++ b/src/styles/transcript/items/IMChatItem.scss
@@ -199,7 +199,7 @@
 
     .chat-item-container {
         width: fit-content;
-        max-width: 70%;
+        max-width: 37%;
 
         position: relative;
 

--- a/src/styles/transcript/items/IMChatItem.scss
+++ b/src/styles/transcript/items/IMChatItem.scss
@@ -479,6 +479,7 @@
         .item-inner {
             padding: var(--padding);
             color: var(--text-color, black);
+            background: var(--bubble-background);
             font-size: var(--font-size);
         }
     }

--- a/src/styles/transcript/items/LPRichLink.scss
+++ b/src/styles/transcript/items/LPRichLink.scss
@@ -8,7 +8,7 @@
         --lp-background-override: var(--dark-lp-background-override);
     }
 
-    background-color: var(--lp-background-override, rgb(229, 230, 233));
+    background-color: var(--lp-background-override, var(--not-from-me));
 
     max-width: 300px;
 


### PR DESCRIPTION
Below are screenshot comparisons between SMServer, macOS, the previous attachment loading in MyMessage, and my changed version. This might not be perfect/final so please let me know what you think of it.
![SMServer](https://user-images.githubusercontent.com/53708281/123874936-dd412f80-d906-11eb-9e2d-c5210cb27871.png)
![Screen Shot 2021-06-29 at 6 02 08 PM](https://user-images.githubusercontent.com/53708281/123874944-df0af300-d906-11eb-897c-d2e1ab8c40a5.png)
![Old MyMessage](https://user-images.githubusercontent.com/53708281/123874961-e5996a80-d906-11eb-8570-b69db8fbdc7b.png)
![New MyMessage](https://user-images.githubusercontent.com/53708281/123874964-e6ca9780-d906-11eb-994f-0ef0fbe2a3dc.png)
![SMServer 2](https://user-images.githubusercontent.com/53708281/123874971-e92cf180-d906-11eb-9efc-5d3d0d28e030.png)
![Screen Shot 2021-06-29 at 6 02 34 PM](https://user-images.githubusercontent.com/53708281/123874978-eaf6b500-d906-11eb-9860-14c1588e9ae6.png)
![Old MyMessage 2](https://user-images.githubusercontent.com/53708281/123874984-ed590f00-d906-11eb-8d6f-4a28e0a67591.png)
![New MyMessage 2](https://user-images.githubusercontent.com/53708281/123874989-ef22d280-d906-11eb-8aed-c9cf4a959287.png)